### PR TITLE
Replace Gitter chat with Element channel 

### DIFF
--- a/conda_forge_artifact_validation/validate.py
+++ b/conda_forge_artifact_validation/validate.py
@@ -234,8 +234,8 @@ about the failure to help you debug it.
 
 **Rerendering the feedstock will usually fix these problems.**
 
-If you have any issues or questions, you can find us on gitter in the
-community [chat room](https://gitter.im/conda-forge/conda-forge.github.io) or you can bump us right here.
+If you have any issues or questions, you can find us on Element in the
+community [channel](https://app.element.io/#/room/#conda-forge:matrix.org) or you can bump us right here.
 """ % team_name  # noqa
 
     if len(valid) > 0:

--- a/scripts/make_admin_requests_broken_prs.py
+++ b/scripts/make_admin_requests_broken_prs.py
@@ -96,7 +96,7 @@ The core team will usually wait a week to merge these PRs. However, they may mer
 deem the packages below a signifcant security or usability issue.
 
 If you think this PR was made by mistake or is incorrect, please get in touch with the core team in this PR or on \
-[gitter](https://gitter.im/conda-forge/conda-forge.github.io)!
+[Element channel](https://app.element.io/#/room/#conda-forge:matrix.org)!
 
 Information on invalid packages (see the files listed under `bad_paths`):
 

--- a/scripts/make_admin_requests_broken_prs.py
+++ b/scripts/make_admin_requests_broken_prs.py
@@ -96,7 +96,7 @@ The core team will usually wait a week to merge these PRs. However, they may mer
 deem the packages below a signifcant security or usability issue.
 
 If you think this PR was made by mistake or is incorrect, please get in touch with the core team in this PR or on \
-[Element channel](https://app.element.io/#/room/#conda-forge:matrix.org)!
+[our Element channel](https://app.element.io/#/room/#conda-forge:matrix.org)!
 
 Information on invalid packages (see the files listed under `bad_paths`):
 


### PR DESCRIPTION
Expanding the scope of - https://github.com/conda-forge/conda-forge.github.io/issues/1677

Replacing Gitter chatroom's  link with Element channel's  link.

cc: @jaimergp 